### PR TITLE
add xml tag for easier json processing

### DIFF
--- a/reflector.cpp
+++ b/reflector.cpp
@@ -418,7 +418,7 @@ void CReflector::WriteXmlFile(std::ofstream &xmlFile)
 {
 	// write header
 	xmlFile << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << std::endl;
-	xmlFile << "<Reflector " << m_Callsign << ">" << std::endl;
+	xmlFile << "<Reflector>" << std::endl;
 
 	// software version
 	char sz[64];
@@ -468,5 +468,5 @@ void CReflector::WriteXmlFile(std::ofstream &xmlFile)
 	xmlFile << "</" << m_Callsign << " heard users>" << std::endl;
 
 	// closing tag
-	xmlFile << "</Reflector " << m_Callsign << ">" << std::endl;
+	xmlFile << "</Reflector>" << std::endl;
 }

--- a/reflector.cpp
+++ b/reflector.cpp
@@ -418,6 +418,7 @@ void CReflector::WriteXmlFile(std::ofstream &xmlFile)
 {
 	// write header
 	xmlFile << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << std::endl;
+	xmlFile << "<Reflector " << m_Callsign << ">" << std::endl;
 
 	// software version
 	char sz[64];
@@ -465,4 +466,7 @@ void CReflector::WriteXmlFile(std::ofstream &xmlFile)
 	// unlock
 	ReleaseUsers();
 	xmlFile << "</" << m_Callsign << " heard users>" << std::endl;
+
+	// closing tag
+	xmlFile << "</Reflector " << m_Callsign << ">" << std::endl;
 }


### PR DESCRIPTION
xml2json complains
```bash
throw new Error('There are errors in your xml file: ' + parser.getError());
Error: There are errors in your xml file: junk after document element
```
due to not having a root element that encompasses all child elements (peer, node, station)

Added in <Reflector (callsign)> </Reflector (callsign)> tags to create a Reflector root element.