### PR TITLE
build support for OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ BINDIR = /usr/local/bin
 CFGDIR = /usr/local/etc
 DATADIR = /var/lib/m17ref
 
-CC = g++
+CC = cc
+CXX = c++
 
 CFLAGS += -c -W -std=c++11 -MMD -MD -c
 
@@ -50,13 +51,13 @@ EXE=mrefd
 all : $(EXE) test-all
 
 test-all : test-all.o crc.o callsign.o
-	$(CC) $^ -o $@
+	$(CXX) $^ -o $@
 
 $(EXE) : $(OBJS)
-	$(CC) $^ -o $@ $(LDFLAGS)
+	$(CXX) $^ -o $@ $(LDFLAGS)
 
 %.o : %.cpp
-	g++ $(CFLAGS) $< -o $@
+	$(CXX) $(CFLAGS) $< -o $@
 
 clean :
 	$(RM) *.o *.d $(EXE) test-all

--- a/rconfig
+++ b/rconfig
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2020 by Thomas A. Early N7TAE
 #


### PR DESCRIPTION
here is a small change to build mrefd on OpenBSD.
(binaries are not tested yet)