### PR TITLE
revise CM17Protocol::clientRegEx, CM17Protocol::peerRegEx

### DIFF
--- a/m17protocol.cpp
+++ b/m17protocol.cpp
@@ -35,8 +35,8 @@
 
 CM17Protocol::CM17Protocol()
 {
-	peerRegEx = std::regex("^M17-([A-Z0-9]){3,3}(()|( [A-Z]))$", std::regex::extended);
-	clientRegEx = std::regex("^[0-9]?[A-Z]{1,2}[0-9]{1,2}[A-Z]{1,4}(()|([ ]*[A-Z]?)|([-/\\.][A-Z0-9]+))$", std::regex::extended);
+	peerRegEx = std::regex("^M17-([A-Z0-9]){3,3}(($)|( [A-Z]$))", std::regex::extended);
+	clientRegEx = std::regex("^[0-9]?[A-Z]{1,2}[0-9]{1,2}[A-Z]{1,4}(($)|([ ]*[A-Z]?$)|([-/\\.][A-Z0-9]+$))", std::regex::extended);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
different from libstdc++ regex, libc++ regex requires POSIX grammer.
empty regex is not allowed, "(()|( [a-z]))$" should be "(($)|( [a-z]$))".

to build mrefd with clang++ (on OpenBSD), this fix is mandatory.