### PR TITLE
revise #include <thread>

### DIFF
--- a/ip.h
+++ b/ip.h
@@ -21,7 +21,6 @@
 #include <iostream>
 #include <cstring>
 #include <chrono>
-#include <thread>
 
 #include <strings.h>
 #include <netinet/in.h>

--- a/main.h
+++ b/main.h
@@ -40,6 +40,7 @@
 #include <iostream>
 #include <iomanip>
 #include <fstream>
+#include <thread>
 #include <arpa/inet.h>
 
 #include "configure.h"


### PR DESCRIPTION
on Arch Linux, g++-11.2.0 says "error: `sleep_for' is not a member
of `std::this_thread'" when compiling timepoint.cpp

move #include <thread> from "ip.h" to "main.h"