### PR TITLE
fix undefined template 'std::basic_istringstream<char>'

### DIFF
--- a/configure.cpp
+++ b/configure.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <iomanip>
 #include <fstream>
+#include <sstream>
 #include <cstring>
 #include <vector>
 #include <algorithm>


### PR DESCRIPTION
to build mrefd on OpenBSD-7.4/amd64 (clang-13), need #include <sstream> to fix this problem.