### PR TITLE
ignore SIGHUP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ else
 CFLAGS += -DNO_DHT
 endif
 
+ifeq ($(SIGHUP), false)
+CFLAGS += -DNO_HUP
+endif
+
 ifeq ("$(OS)","Windows_NT")
 CFLAGS += -D_GNU_SOURCE
 endif

--- a/example.mk
+++ b/example.mk
@@ -16,3 +16,6 @@ DEBUG = false
 
 # To disable DHT support, set DHT to false.
 DHT = true
+
+# To disable SIGHUP handling, set SIGHUP to false.
+SIGHUP = true

--- a/main.cpp
+++ b/main.cpp
@@ -50,7 +50,6 @@ void SigHandler(int sig)
 int main(int argc, char *argv[])
 {
 	std::signal(SIGINT, SigHandler);
-	std::signal(SIGHUP, SigHandler);
 	std::signal(SIGTERM, SigHandler);
 	if (2 != argc)
 	{

--- a/main.cpp
+++ b/main.cpp
@@ -37,7 +37,9 @@ void SigHandler(int sig)
 	switch (sig)
 	{
 	case SIGINT:
+#ifndef NO_HUP
 	case SIGHUP:
+#endif
 	case SIGTERM:
 		std::cout << "caught a signal=" << sig << std::endl;
 		break;
@@ -50,7 +52,9 @@ void SigHandler(int sig)
 int main(int argc, char *argv[])
 {
 	std::signal(SIGINT, SigHandler);
+#ifndef NO_HUP
 	std::signal(SIGHUP, SigHandler);
+#endif
 	std::signal(SIGTERM, SigHandler);
 	if (2 != argc)
 	{

--- a/main.cpp
+++ b/main.cpp
@@ -50,6 +50,7 @@ void SigHandler(int sig)
 int main(int argc, char *argv[])
 {
 	std::signal(SIGINT, SigHandler);
+	std::signal(SIGHUP, SigHandler);
 	std::signal(SIGTERM, SigHandler);
 	if (2 != argc)
 	{


### PR DESCRIPTION
I know this project is for systemd-base Linux system, but I cannot invoke mrefd from rc.local script of OpenBSD.
I found OpenBSD sends SIGHUP signal to programs that invoked by rc.local, so program needs to handle this signal properly. 

Current code quits mrefd after received SIGHUP.
If there is no need to use SIGHUP, please ignore it (old mrefd does nothing for any signals).