### PR TITLE
add daemonize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ else
 CFLAGS += -DNO_DHT
 endif
 
+ifeq ($(DAEMON), true)
+CFLAGS += -DRUN_AS_DAEMON
+endif
+
 ifeq ("$(OS)","Windows_NT")
 CFLAGS += -D_GNU_SOURCE
 endif

--- a/example.mk
+++ b/example.mk
@@ -16,3 +16,6 @@ DEBUG = false
 
 # To disable DHT support, set DHT to false.
 DHT = true
+
+# To enable daemonize, set DAEMON to true.
+DAEMON = false

--- a/main.cpp
+++ b/main.cpp
@@ -49,14 +49,21 @@ void SigHandler(int sig)
 
 int main(int argc, char *argv[])
 {
+	if (2 != argc)
+	{
+		std::cerr << "USAGE: " << argv[0] << " </full/pathname/to/config/file>" << std::endl;
+		return EXIT_FAILURE;
+	}
+
+#ifdef RUN_AS_DAEMON
+	if (0 > daemon(1, 1))
+		return EXIT_FAILURE;
+#endif
+
 	std::signal(SIGINT, SigHandler);
 	std::signal(SIGHUP, SigHandler);
 	std::signal(SIGTERM, SigHandler);
-	if (2 != argc)
-	{
-		std::cerr << "USAGE: " << argv[0] << " /full/pathname/to/config/file>" << std::endl;
-		return EXIT_FAILURE;
-	}
+
 	// remove pidfile
 	remove(g_CFG.GetPidPath().c_str());
 


### PR DESCRIPTION
it is easy way to avoid SIGHUP issue on *BSD environment, add daemonize.
for previous mrefd.mk compatibility, daemonize is disabled as default.

fix typo ,and signal handler is defined after fork().
