### PR TITLE
fix -Wtype-limits for test-all.cpp

### DIFF
--- a/callsign.h
+++ b/callsign.h
@@ -32,7 +32,7 @@ public:
 	void CodeIn(const uint8_t *code);
 	const std::string GetCS(unsigned len = 0) const;
 	void CodeOut(uint8_t *out) const;
-	size_t Hash() const { return coded; }
+	uint64_t Hash() const { return coded; }
 	bool operator==(const CCallsign &rhs) const;
 	bool operator!=(const CCallsign &rhs) const;
 	char GetModule(void) const;


### PR DESCRIPTION
building mrefd on Slackware-15.0/i686 says
```
test-all.cpp: In function ‘int main()’:
test-all.cpp:18:19: warning: comparison is always false due to limited range of data type [-Wtype-limits]
   18 |         if (coded == 0x05f74c74caedu)
      |             ~~~~~~^~~~~~~~~~~~~~~~~~
```

maybe size_t is 32bit, Hash() should be 64bit.