### PR TITLE
Logo moved to navbar, big logo removed, css changes.

### DIFF
--- a/php-dash/css/dashboard.css
+++ b/php-dash/css/dashboard.css
@@ -66,6 +66,18 @@ a.tip:hover span {
   color: #9d9d9d;
 }
 
+.navbar-circular-container {
+  width: 42px; /* Set the desired width of the container */
+  height: 42px; /* Set the desired height of the container */
+  overflow: hidden; /* Hide any overflowing parts of the image */
+  border-radius: 50%; /* Make the container circular */
+}
+
+.navbar-circular-image {
+  width: 100%; /* Make the image fill the container */
+  height: 100%; /* Make the image fill the container */
+}
+
 /*
  * Sidebar
  */

--- a/php-dash/include/users.php
+++ b/php-dash/include/users.php
@@ -142,7 +142,6 @@ if (isset($_GET['do'])) {
 </div>
 
 <div class="col-md-3">
-    <?php echo '<a href="' . $PageOptions['Homepage'] . '"><img class="mx-auto d-none d-md-block" src="./images/' . $PageOptions['Logo'] . '" width="50%"></a>'; ?>
     <table class="table table-sm table-striped table-hover">
         <?php 
             $Modules = $Reflector->GetModules();

--- a/php-dash/index.php
+++ b/php-dash/index.php
@@ -101,6 +101,9 @@ $Reflector->LoadXML();
     include_once("tracking.php");
 } ?>
 <nav class="navbar navbar-expand-lg navbar-dark fixed-top bg-dark">
+    <nav class="navbar-circular-container">
+    <img style="background-color:white;" src="images/icons/favicon-96x96.png" class="navbar-circular-image">
+    </img> </nav>&nbsp;&nbsp;
     <a class="navbar-brand" href="#"><?php echo $Reflector->GetReflectorName(); ?> Reflector</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
The M17 logo is moved to the nav bar. The big logo to the right of the last heard section is removed, and CSS modifications to make the logo look decent in the nav bar.