### PR TITLE
fix warnings on clang (with FreeBSD and OpenBSD)

### DIFF
--- a/parrot.h
+++ b/parrot.h
@@ -35,6 +35,7 @@ class CParrot
 {
 public:
 	CParrot(const uint8_t *src_addr, SPClient spc, uint16_t ft) : src(src_addr), client(spc), frameType(ft), state(EParrotState::record) {}
+	virtual ~CParrot() {}
 	virtual void Add(const CPacket &pack) = 0;
 	virtual bool IsExpired() const = 0;
 	virtual void Play() = 0;

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -146,7 +146,7 @@ void CProtocol::Thread()
 void CProtocol::Task(void)
 {
 	CIp ip;
-	char mod;
+	char mod = 0;
 	char mods[27];
 	CCallsign cs;
 	CPacket pack;


### PR DESCRIPTION
I tried to build recent mrefd on FreeBSD and OpenBSD, some warnings has occured.
Here is the fix. No bad effect for Linux.
